### PR TITLE
Fix TypeScript build errors on Node current

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,7 @@
       "devDependencies": {
         "@tsconfig/node-lts": "^20.1.0",
         "@tsconfig/strictest": "^2.0.2",
+        "@types/node": "^25.5.0",
         "@types/serverless": "^3.12.19",
         "eslint": "^8.56.0",
         "eslint-config-domdomegg": "^1.2.3",
@@ -948,12 +949,14 @@
       "dev": true
     },
     "node_modules/@types/node": {
-      "version": "18.11.18",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.11.18.tgz",
-      "integrity": "sha512-DHQpWGjyQKSHj3ebjFI/wRKcqQcdR+MoFBygntYOZytCqNfkd2ZC4ARDJ2DQqhjH5p85Nnd3jhUJIXrszFX/JA==",
+      "version": "25.5.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.5.0.tgz",
+      "integrity": "sha512-jp2P3tQMSxWugkCUKLRPVUpGaL5MVFwF8RDuSRztfwgN1wmqJeMSbKlnEtQqU8UrhTmzEmZdu2I6v2dpp7XIxw==",
       "dev": true,
-      "optional": true,
-      "peer": true
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~7.18.0"
+      }
     },
     "node_modules/@types/semver": {
       "version": "7.5.6",
@@ -5537,6 +5540,13 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/undici-types": {
+      "version": "7.18.2",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.18.2.tgz",
+      "integrity": "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/unpipe": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
@@ -6503,12 +6513,13 @@
       "dev": true
     },
     "@types/node": {
-      "version": "18.11.18",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.11.18.tgz",
-      "integrity": "sha512-DHQpWGjyQKSHj3ebjFI/wRKcqQcdR+MoFBygntYOZytCqNfkd2ZC4ARDJ2DQqhjH5p85Nnd3jhUJIXrszFX/JA==",
+      "version": "25.5.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.5.0.tgz",
+      "integrity": "sha512-jp2P3tQMSxWugkCUKLRPVUpGaL5MVFwF8RDuSRztfwgN1wmqJeMSbKlnEtQqU8UrhTmzEmZdu2I6v2dpp7XIxw==",
       "dev": true,
-      "optional": true,
-      "peer": true
+      "requires": {
+        "undici-types": "~7.18.0"
+      }
     },
     "@types/semver": {
       "version": "7.5.6",
@@ -9839,6 +9850,12 @@
         "has-symbols": "^1.0.3",
         "which-boxed-primitive": "^1.0.2"
       }
+    },
+    "undici-types": {
+      "version": "7.18.2",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.18.2.tgz",
+      "integrity": "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==",
+      "dev": true
     },
     "unpipe": {
       "version": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
   "devDependencies": {
     "@tsconfig/node-lts": "^20.1.0",
     "@tsconfig/strictest": "^2.0.2",
+    "@types/node": "^25.5.0",
     "@types/serverless": "^3.12.19",
     "eslint": "^8.56.0",
     "eslint-config-domdomegg": "^1.2.3",

--- a/src/index.ts
+++ b/src/index.ts
@@ -46,7 +46,7 @@ class ServerlessOfflineSesV2Plugin implements Plugin {
     this.serverless.cli.log(`${PLUGIN_NAME}: stopping server...`);
 
     await Promise.allSettled(this.servers.map((s) => new Promise<void>((resolve, reject) => {
-      s.close((err) => {
+      s.close((err: Error | undefined) => {
         if (err) {
           reject(err);
         } else {


### PR DESCRIPTION
## Summary

- Add `@types/node` as an explicit devDependency to resolve `Cannot find module 'http'` error
- Type the `err` callback parameter in `server.close()` to fix `noImplicitAny` violation
- Fixes the CI build failure on the `current` Node.js matrix entry